### PR TITLE
Fix minor bug in User Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,12 +40,14 @@ TaskYapper helps you manage your tasks efficiently with a variety of commands. B
 - **Command Descriptor:** `deadline`
 - **Format:** `deadline <task_description> /by <date: yyyy-mm-dd>`
 - **Example:** `deadline cs2103t ip /by 2024-02-23` adds a new deadline task.
+
 > Note that deadlines require a date, representing the date this task should be done by.
 
 ### Adding an Event Task
-- **Command Descriptor:** `add_event`
-- **Format:** `add_event <task_description> /from <date: yyyy-mm-dd> /to <date: yyyy-mm-dd>`
-- **Example:** `add_event ay23/24 semester 2 /from 2024-01-15 /to 2024-05-11` adds a new event task.
+- **Command Descriptor:** `event`
+- **Format:** `event <task_description> /from <date: yyyy-mm-dd> /to <date: yyyy-mm-dd>`
+- **Example:** `event ay23/24 semester 2 /from 2024-01-15 /to 2024-05-11` adds a new event task.
+
 > Note that events require a start date and an end date.
 
 ### Exiting the Application


### PR DESCRIPTION
The command descriptor for adding an event should be `event` not `add_event`